### PR TITLE
Switched method of getting Network Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ node program.js
 BACnet Server Example NodeJS
 https://github.com/chipkin/BACnetServerExampleNodeJS
 GetLibaryPath: ./bin/CASBACnetStack_x64_Debug.dll
-Application Version: 1.1.0.0, BACnetStack_Version: 3.30.2.0, BACnetStackAdapter_Version: 1.1.0.0
+Application Version: 1.2.0.0, BACnetStack_Version: 3.30.2.0, BACnetStackAdapter_Version: 1.1.0.0
 
 FYI: Setting up callback functions...
 FYI: Setting up BACnet device...

--- a/README.md
+++ b/README.md
@@ -28,7 +28,16 @@ A basic BACnet IP server example written in NodeJS using the [CAS BACnet Stack](
 ## Installation
 
 1. Place `CASBACnetStack_x64_Debug.dll` into `REPO_DIR/bin/`
-2. Run the following
+2. (optional) Set network settings at program.js:30, if left empty the program will get your system's active network configuration
+```js
+// Settings
+const SETTING_BACNET_PORT = 47808;  // Default BACnet IP UDP Port.
+const SETTING_DEFAULT_GATEWAY = []; // Set Default Gateway to use for BACnet (i.e. [192, 168, 1, 3])
+const SETTING_IP_ADDRESS = [];      // Set IP Address to use for BACnet (i.e. [192, 168, 1, 3])
+const SETTING_SUBNET_MASK = [];     // Set Subnet Mask to use for BACnet (i.e. [255, 255, 255, 0])
+```
+
+3. Run the following
 ```bash
 
 sudo apt install build-essential

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
     "description": "An example server application for the CAS BACnet Stack",
     "main": "program.js",
     "dependencies": {
+        "default-gateway": "^6.0.3",
         "dequeue": "^1.0.5",
         "ffi-napi": "^4.0.3",
-        "network": "^0.6.1",
         "ref-napi": "^3.0.3",
-        "winston": "^3.6.0"
+        "winston": "^3.6.0",
+        "wmic": "^1.1.1"
     },
     "scripts": {
         "start": "node program.js"

--- a/program.js
+++ b/program.js
@@ -1479,12 +1479,14 @@ function main() {
 
     // Get netmask and ip address
     const networkInterfaces = os.networkInterfaces();
+    var localAddressString = '';
     for (localNetwork in networkInterfaces) {
         networkInterfaces[localNetwork].forEach(function (adapter) {
             // NOTE: Specify your network here with your own filters
             let addressIterator = adapter.address.split('.').map(Number);
             if (addressIterator[0] === 192 && addressIterator[2] === 1) {
                 localAddress = adapter.address.split('.').map(Number);
+                localAddressString = adapter.address;
                 subnetMask = adapter.netmask.split('.').map(Number);
             }
         });
@@ -1540,7 +1542,7 @@ function main() {
 
     // TODO: We manual set server address until we find reliable way of getting ip
     server.bind({
-        address: '192.168.1.159',
+        address: localAddressString,
         port: SETTING_BACNET_PORT
     });
 

--- a/program.js
+++ b/program.js
@@ -1472,9 +1472,8 @@ function main() {
     // Setup Network Parameters
     // ------------------------------------------------------------------------
     // Get Local IP
-    // TODO: Use manual defaultGateway value for now - couldn't retrieve network info properly
     var localAddress = [];
-    var defaultGateway = [192, 168, 1, 20];
+    var defaultGateway = [];
     var subnetMask = [];
 
     // Get netmask and ip address

--- a/program.js
+++ b/program.js
@@ -3,7 +3,7 @@
 // Start with the "function main()"
 //
 // Written by: Steven Smethurst
-// Last updated: Mar 24, 2022
+// Last updated: Mar 25, 2022
 //
 
 var CASBACnetStack = require('./CASBACnetStackAdapter'); // CAS BACnet stack
@@ -33,7 +33,7 @@ const SETTING_IP_ADDRESS = []; // Set IP Address to use for BACnet, set to [] to
 const SETTING_SUBNET_MASK = []; // Set Subnet Mask to use for BACnet, set to [] to discover
 
 // Constants
-const APPLICATION_VERSION = '1.1.0.0';
+const APPLICATION_VERSION = '1.2.0.0';
 
 // Globals
 var fifoSendBuffer = new dequeue();


### PR DESCRIPTION
Switched over from `network` library to use `os.networkInterfaces()` and `default-gateway` library to get network parameters.

Also removed hardcoded ip addresses and default gateway